### PR TITLE
Demonstrate that Expo public env vars can't be set in Jest

### DIFF
--- a/App.test.ts
+++ b/App.test.ts
@@ -1,0 +1,17 @@
+describe('process.env', () => {
+  it('env vars should be settable in Jest setup files', () => {
+    // this works
+    expect(process.env.THIS_IS_A_TEST).toBe('test');
+  });
+
+  it('expo public env vars should be settable in Jest setup files', () => {
+    // this doesn't
+    expect(process.env.EXPO_PUBLIC_THIS_IS_A_TEST).toBe('test');
+  });
+
+  it('expo public env vars should be settable in Jest', () => {
+    // this doesn't
+    process.env.EXPO_PUBLIC_THIS_IS_ANOTHER_TEST = 'test';
+    expect(process.env.EXPO_PUBLIC_THIS_IS_ANOTHER_TEST).toBe('test');
+  });
+});

--- a/jest-setup.ts
+++ b/jest-setup.ts
@@ -1,0 +1,2 @@
+process.env.THIS_IS_A_TEST = 'test';
+process.env.EXPO_PUBLIC_THIS_IS_A_TEST = 'test';

--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
     "preset": "jest-expo",
     "transformIgnorePatterns": [
       "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg)"
+    ],
+    "setupFiles": [
+      "./jest-setup.ts"
     ]
   }
 }


### PR DESCRIPTION
```sh
npm i
npm test
```