### PR TITLE
OneSignal opt-in/opt-out state stops updating after restarting app

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,10 +1,50 @@
+import { useEffect, useState } from 'react';
 import { StatusBar } from 'expo-status-bar';
-import { StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, Text, View, Button } from 'react-native';
+import { LogLevel, OneSignal } from 'react-native-onesignal';
 
 export default function App() {
+  const [optedIn, setOptedIn] = useState(false);
+
+  useEffect(() => {
+    function subsciptionChanged(event) {
+      setOptedIn(event.current.optedIn);
+    }
+
+    OneSignal.Debug.setLogLevel(LogLevel.Verbose);
+    OneSignal.initialize(process.env.EXPO_PUBLIC_ONESIGNAL_APP_ID);
+
+    OneSignal.Location.setShared(false);
+
+    OneSignal.User.pushSubscription.addEventListener(
+      'change',
+      subsciptionChanged
+    );
+
+    return () => {
+      OneSignal.User.pushSubscription.removeEventListener(
+        'change',
+        subsciptionChanged
+      );
+    };
+  }, []);
+
   return (
     <View style={styles.container}>
-      <Text>Open up App.tsx to start working on your app!</Text>
+      <Text>{optedIn ? 'Opted in!' : 'Opted out!'}</Text>
+
+      <Button
+        onPress={() => OneSignal.User.pushSubscription.optIn()}
+        title="Opt In"
+        color="#841584"
+      />
+
+      <Button
+        onPress={() => OneSignal.User.pushSubscription.optOut()}
+        title="Opt Out"
+        color="#841584"
+      />
+
       <StatusBar style="auto" />
     </View>
   );

--- a/app.json
+++ b/app.json
@@ -27,6 +27,14 @@
     },
     "web": {
       "favicon": "./assets/favicon.png"
-    }
+    },
+    "plugins": [
+      [
+        "onesignal-expo-plugin",
+        {
+          "mode": "development"
+        }
+      ]
+    ]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,10 @@
         "expo-status-bar": "~1.11.1",
         "jest": "^29.3.1",
         "jest-expo": "~50.0.1",
+        "onesignal-expo-plugin": "^2.0.2",
         "react": "18.2.0",
-        "react-native": "0.73.2"
+        "react-native": "0.73.2",
+        "react-native-onesignal": "^5.0.5"
       },
       "devDependencies": {
         "@babel/core": "^7.20.0",
@@ -13928,6 +13930,196 @@
         "wrappy": "1"
       }
     },
+    "node_modules/onesignal-expo-plugin": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/onesignal-expo-plugin/-/onesignal-expo-plugin-2.0.2.tgz",
+      "integrity": "sha512-KVzoNCYkZYjRJOpn2k1CcY1PRVuMMnW/XV5zwEGh7MVnXyLIBHD9I2Yf6dlRa6iPE10qBeWmDD3jZuMB1993hg==",
+      "dependencies": {
+        "@expo/image-utils": "^0.3.22"
+      }
+    },
+    "node_modules/onesignal-expo-plugin/node_modules/@expo/image-utils": {
+      "version": "0.3.23",
+      "resolved": "https://registry.npmjs.org/@expo/image-utils/-/image-utils-0.3.23.tgz",
+      "integrity": "sha512-nhUVvW0TrRE4jtWzHQl8TR4ox7kcmrc2I0itaeJGjxF5A54uk7avgA0wRt7jP1rdvqQo1Ke1lXyLYREdhN9tPw==",
+      "dependencies": {
+        "@expo/spawn-async": "1.5.0",
+        "chalk": "^4.0.0",
+        "fs-extra": "9.0.0",
+        "getenv": "^1.0.0",
+        "jimp-compact": "0.16.1",
+        "mime": "^2.4.4",
+        "node-fetch": "^2.6.0",
+        "parse-png": "^2.1.0",
+        "resolve-from": "^5.0.0",
+        "semver": "7.3.2",
+        "tempy": "0.3.0"
+      }
+    },
+    "node_modules/onesignal-expo-plugin/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/onesignal-expo-plugin/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/onesignal-expo-plugin/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/onesignal-expo-plugin/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/onesignal-expo-plugin/node_modules/crypto-random-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+      "integrity": "sha512-GsVpkFPlycH7/fRR7Dhcmnoii54gV1nz7y4CWyeFS14N+JVBBhY+r8amRHE4BwSYal7BPTDp8isvAlCxyFt3Hg==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/onesignal-expo-plugin/node_modules/fs-extra": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.0.tgz",
+      "integrity": "sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/onesignal-expo-plugin/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/onesignal-expo-plugin/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/onesignal-expo-plugin/node_modules/jsonfile/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/onesignal-expo-plugin/node_modules/semver": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/onesignal-expo-plugin/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/onesignal-expo-plugin/node_modules/temp-dir": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
+      "integrity": "sha512-xZFXEGbG7SNC3itwBzI3RYjq/cEhBkx2hJuKGIUOcEULmkQExXiHat2z/qkISYsuR+IKumhEfKKbV5qXmhICFQ==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/onesignal-expo-plugin/node_modules/tempy": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/tempy/-/tempy-0.3.0.tgz",
+      "integrity": "sha512-WrH/pui8YCwmeiAoxV+lpRH9HpRtgBhSR2ViBPgpGb/wnYDzp21R4MN45fsCGvLROvY67o3byhJRYRONJyImVQ==",
+      "dependencies": {
+        "temp-dir": "^1.0.0",
+        "type-fest": "^0.3.1",
+        "unique-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/onesignal-expo-plugin/node_modules/type-fest": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+      "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/onesignal-expo-plugin/node_modules/unique-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+      "integrity": "sha512-ODgiYu03y5g76A1I9Gt0/chLCzQjvzDy7DsZGsLOE/1MrF6wriEskSncj1+/C58Xk/kPZDppSctDybCwOSaGAg==",
+      "dependencies": {
+        "crypto-random-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/onesignal-expo-plugin/node_modules/universalify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+      "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/onetime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
@@ -14719,6 +14911,14 @@
       },
       "peerDependencies": {
         "react": "18.2.0"
+      }
+    },
+    "node_modules/react-native-onesignal": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/react-native-onesignal/-/react-native-onesignal-5.0.5.tgz",
+      "integrity": "sha512-M+i45FTW+F88mNYVvIv1nlf2c4OxQcHozjsmcbPUP+zvQyvMGjvkEDXl7SuCjD2FlebEnl1BIZm2cphEaVJTmQ==",
+      "dependencies": {
+        "invariant": "^2.2.2"
       }
     },
     "node_modules/react-native/node_modules/promise": {

--- a/package.json
+++ b/package.json
@@ -15,8 +15,10 @@
     "expo-status-bar": "~1.11.1",
     "jest": "^29.3.1",
     "jest-expo": "~50.0.1",
+    "onesignal-expo-plugin": "^2.0.2",
     "react": "18.2.0",
-    "react-native": "0.73.2"
+    "react-native": "0.73.2",
+    "react-native-onesignal": "^5.0.5"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",


### PR DESCRIPTION
Demo of https://github.com/OneSignal/react-native-onesignal/issues/1625

1. https://reactnative.dev/docs/environment-setup?guide=native
2. `git clone -b onesignal-bug-demo https://github.com/chriszs/test-expo-app.git`
3. `cd test-expo-app`
4. `npm i`
5. `echo "EXPO_PUBLIC_ONESIGNAL_APP_ID=<ONESIGNAL_ID_HERE>" > .env`
6. `npm run android`
7. Tap "OPT IN", tap "OPT OUT" (text should update accordingly)
8. Tap the overview (square) hardware or soft button or swipe up on the bar at the bottom of the Android screen to view the app changer, then swipe up on the card representing this app to close it
9. Reopen the app
10. Tap "OPT IN", tap "OPT OUT" (text may not update)
11. If text updates, repeat 8-10 until it stops
